### PR TITLE
Queue consumer to process one message at a time

### DIFF
--- a/scripts/migration/queueStatefulMigration.js
+++ b/scripts/migration/queueStatefulMigration.js
@@ -89,7 +89,8 @@ export class QueueStatefulMigration {
     console.time(`Time to send ${process.env.QUERY_LIMIT || 100} transactions to queue:`);
     const channel = await this.getAmqpChannel();
     await channel.assertQueue(config.queue.transactionQueue, { exclusive: false });
-    channel.sendToQueue(config.queue.transactionQueue, Buffer.from(JSON.stringify(transactions), 'utf8'));
+    channel.sendToQueue(config.queue.transactionQueue,
+      Buffer.from(JSON.stringify(transactions), 'utf8'), { persistent: true });
     console.timeEnd(`Time to send ${process.env.QUERY_LIMIT || 100} transactions to queue:`);
   }
 


### PR DESCRIPTION
Adding `ack` and `prefetch` as well as making the queue `durable(consumer) and persistent(publisher)` .